### PR TITLE
fix: switch from Netlify to Vercel adapter in Astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
 import db from "@astrojs/db";
 
-import netlify from "@astrojs/netlify";
+import vercel from "@astrojs/vercel/serverless";
 
 // https://astro.build/config
 export default defineConfig({
@@ -18,5 +18,7 @@ export default defineConfig({
   redirects: {},
 
   integrations: [react(), db()],
-  adapter: netlify({}),
+  adapter: vercel({
+    edgeMiddleware: true,
+  }),
 });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@astrojs/db": "0.17.1",
-    "@astrojs/netlify": "6.5.9",
     "@astrojs/react": "4.3.0",
+    "@astrojs/vercel": "8.2.7",
     "@formkit/tempo": "0.1.2",
     "@hookform/resolvers": "5.0.1",
     "@tailwindcss/vite": "4.1.3",


### PR DESCRIPTION
This pull request updates the deployment platform for the Astro app from Netlify to Vercel. The configuration and dependencies have been changed to support Vercel’s serverless adapter and edge middleware.

**Deployment platform migration:**

* Replaced the Netlify adapter with the Vercel serverless adapter in `astro.config.mjs`, enabling edge middleware support. [[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL7-R7) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL21-R23)
* Removed `@astrojs/netlify` and added `@astrojs/vercel` to the dependencies in `package.json`.